### PR TITLE
Use raw string for re.compile

### DIFF
--- a/dh_poinstaller
+++ b/dh_poinstaller
@@ -68,7 +68,7 @@ class DHelper():
         return packages
     
     def get_po_orig(self, packages):
-        reg = re.compile("([\w-]+)\s+(.*)")
+        reg = re.compile(r'([\w-]+)\s+(.*)')
         for pkg in packages.keys():
             if 'pofiles' in packages[pkg].keys() and packages[pkg]['pofiles'] is not None:
                 with open(packages[pkg]['pofiles'], 'r', encoding='utf-8') as fd:


### PR DESCRIPTION
re.compile requires a raw string as input.